### PR TITLE
Add rvmsudo as an option to the config file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,15 @@
 PATH
   remote: .
   specs:
-    work (0.1.0)
+    work (0.2.0)
       sys-uname (>= 0.8.5)
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.2)
+    ffi (1.0.11)
+    rake (0.9.2.2)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
       rspec-expectations (~> 2.6.0)
@@ -16,13 +18,13 @@ GEM
     rspec-expectations (2.6.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.6.0)
-    sys-uname (0.8.5)
-    yard (0.6.8)
+    sys-uname (0.9.0)
+      ffi (>= 1.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  rake
   rspec (>= 2.5.0)
   work!
-  yard (>= 0.6.4)

--- a/Rakefile
+++ b/Rakefile
@@ -17,14 +17,14 @@ task :default => [:start, :spec, :stop]
 # Yard
 #
 
-begin
-  require 'yard'
-  YARD::Rake::YardocTask.new
-rescue LoadError
-  task :yardoc do
-    abort "YARD is not available. In order to run yardoc, you must: sudo gem install yard"
-  end
-end
+# begin
+#   require 'yard'
+#   YARD::Rake::YardocTask.new
+# rescue LoadError
+#   task :yardoc do
+#     abort "YARD is not available. In order to run yardoc, you must: sudo gem install yard"
+#   end
+# end
 
 
 #

--- a/bin/work
+++ b/bin/work
@@ -9,7 +9,13 @@ require 'work'
 def sudome
   if ENV["USER"] != "root"
     # `exec` replaces this process, so no need to `exit` as well.
-    exec("sudo #{$0} #{ARGV.join(' ')}")
+    dotfile = Work::DotFile.locate
+    
+    if dotfile.exists? and dotfile.rvm
+      exec("rvmsudo #{$0} #{ARGV.join(' ')}")
+    else
+      exec("sudo #{$0} #{ARGV.join(' ')}")
+    end
   end
 end
 
@@ -23,7 +29,7 @@ if ARGV.first == 'setup'
     puts "Work file already exists at #{dotfile.path}"
   else
     dotfile.write!
-    puts "Default work domains added to #{dotfile.path}"
+    puts "Default work domains added to #{dotfile.path}. Remember to the rvm configuration if you're running that!"
   end
 
 # Not a setup command, so we'll need the `Teacher`

--- a/lib/work.rb
+++ b/lib/work.rb
@@ -14,6 +14,7 @@ module Work
     news.ycombinator.com nytimes.com radar.oreilly.com readwriteweb.com
     reddit.com techcrunch.com techmeme.com torrentfreak.com tuaw.com
     tweetmeme.com venturebeat.com wired.com youtube.com zdnet.com zenhabits.net
+    twitter.com
   }
 
   class HostsFileNotWritable < StandardError; end

--- a/lib/work/dotfile.rb
+++ b/lib/work/dotfile.rb
@@ -3,7 +3,7 @@ require 'yaml'
 module Work
   class DotFile
 
-    attr_accessor :path, :ip, :domains
+    attr_accessor :path, :ip, :domains, :rvm
     attr_writer :ip, :domains
 
     def self.locate
@@ -31,13 +31,19 @@ module Work
       if exists?
         data = YAML.load_file(path)
         self.ip = data["ip"] if data.has_key?("ip")
+        self.rvm = if data.has_key?("rvm")
+          data["rvm"] 
+        else
+          false
+        end
+        
         self.domains = data["domains"].sort if data.has_key?("domains")
       end
     end
 
     def write!
       File.open(path, 'w+') do |f|
-        f.write YAML::dump({ "ip" => ip, "domains" => domains })
+        f.write YAML::dump({ "ip" => ip, "rvm" => false, "domains" => domains })
       end
     end
 

--- a/work.gemspec
+++ b/work.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'sys-uname', '>= 0.8.5'
 
   s.add_development_dependency 'rspec', '>= 2.5.0'
-  s.add_development_dependency 'yard', '>= 0.6.4'
+  s.add_development_dependency 'rake'
+  # s.add_development_dependency 'yard', '~> 0.7.0'
 end


### PR DESCRIPTION
This pull request adds the option of using `rvmsudo` instead of `sudo`. This way, using this gem with RVM should not be an issue.

Also adds twitter.com to the default sites.
